### PR TITLE
Julien contribute option

### DIFF
--- a/components/contents/ContentsSkeleton.vue
+++ b/components/contents/ContentsSkeleton.vue
@@ -26,9 +26,41 @@
           </code>
         </div>
       </div>
-
     </div>
 
+    <!-- OPTION CONTRIBUTION BTN LINK -->
+    <div
+      v-show="contrib"
+      class="content floating-contrib">
+      <b-tooltip
+        multilined
+        class="icon-contrib"
+        type="is-dark"
+        size="is-large"
+        position="is-left"
+        >
+        <template v-slot:content>
+          <p class="mb-1">
+            {{ $translate('contribText', dict) }}
+          </p>
+          <p class="mb-1">
+            {{ $translate('fileText', dict) }} :
+            <b>{{ fileName }}</b>
+          </p>
+        </template>
+        <b-button
+          size="is-small"
+          type="is-text"
+          tag="a"
+          :href="convertPublicUrl"
+          target="_blank">
+          <b-icon
+            icon="git"
+            type="is-grey-lighter"
+          />
+        </b-button>
+      </b-tooltip>
+    </div>
 
     <LogoAnimated
       v-if="section.component === 'LogoAnimated' && sectionData"
@@ -92,6 +124,34 @@
       </div> -->
     </div>
 
+    <!-- <section
+      v-show="contrib"
+      class="has-text-centered mt-0 mb-6">
+      <b-tooltip
+        multilined
+        type="is-dark"
+        size="is-medium"
+        position="is-right"
+        >
+        <template v-slot:content>
+          {{ $translate('sourceFile', dict) }} :
+          <br>
+          <b>{{ fileName }}</b>
+        </template>
+        <b-button
+          size="is-small"
+          type="is-text"
+          tag="a"
+          :href="convertUrl"
+          target="_blank">
+          <b-icon
+            icon="git"
+            type="is-grey-lighter"
+          />
+        </b-button>
+      </b-tooltip>
+    </section> -->
+
   </div>
 </template>
 
@@ -114,19 +174,28 @@ export default {
   props: [
     'section',
     'sectionIndex',
+    'contrib',
     'debug'
   ],
   data() {
     return {
       sectionData: undefined,
+      dict: {
+        contribText: {
+          fr: 'Cliquez pour contribuer à améliorer cette section sur le repo',
+          en: 'Click to contribute improving this section on the repository'
+        },
+        fileText: {
+          fr: 'Fichier',
+          en: 'File'
+        }
+      }
     }
   },
   head () {
     return {
-      link: [
-      ],
-      script: [
-      ],
+      link: [],
+      script: []
     }
   },
   computed: {
@@ -134,13 +203,24 @@ export default {
       log: (state) => state.log,
       locale: (state) => state.locale,
       localeFallback: (state) => state.localeFallback,
-      gitInfos: (state) =>  state.gitInfos,
+      gitInfos: (state) =>  state.gitInfos
     }),
     ...mapGetters({
       rawRoot : 'getGitRawRoot',
+      publicRoot : 'getGitPublicRoot'
     }),
+    sectionFile () {
+      return this.section.files[this.locale] || this.section.files[this.localeFallback]
+    },
+    fileName () {
+      return this.sectionFile.split('/').at(-1)
+    },
     convertUrl() {
-      const url = `${this.rawRoot}${this.section.files[this.locale] || this.section.files[this.localeFallback] }`
+      const url = `${this.rawRoot}${this.sectionFile}`
+      return url
+    },
+    convertPublicUrl() {
+      const url = `${this.publicRoot}${this.sectionFile}`
       return url
     },
     sectionOptions() {
@@ -177,3 +257,13 @@ export default {
 
 }
 </script>
+
+<style scoped>
+  .floating-contrib {
+    float: right;
+  }
+  .icon-contrib {
+    left: 20px;
+    top: 20px;
+  }
+</style>

--- a/components/contents/ContentsSkeleton.vue
+++ b/components/contents/ContentsSkeleton.vue
@@ -30,7 +30,7 @@
 
     <!-- OPTION CONTRIBUTION BTN LINK -->
     <div
-      v-show="contrib"
+      v-if="contrib"
       class="content floating-contrib">
       <b-tooltip
         multilined
@@ -43,6 +43,7 @@
           <p class="mb-1">
             {{ $translate('contribText', dict) }}
           </p>
+          <hr class="my-1">
           <p class="mb-1">
             {{ $translate('fileText', dict) }} :
             <b>{{ fileName }}</b>
@@ -210,10 +211,10 @@ export default {
       publicRoot : 'getGitPublicRoot'
     }),
     sectionFile () {
-      return this.section.files[this.locale] || this.section.files[this.localeFallback]
+      return this.section.files && (this.section.files[this.locale] || this.section.files[this.localeFallback])
     },
     fileName () {
-      return this.sectionFile.split('/').at(-1)
+      return this.sectionFile && this.sectionFile.split('/').at(-1)
     },
     convertUrl() {
       const url = `${this.rawRoot}${this.sectionFile}`

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -39,6 +39,7 @@
           <ContentsSkeleton
             :section="section"
             :section-index="idx"
+            :contrib="routeHasContrib || sectionHasContrib(section)"
             :debug="false"
           />
         </div>
@@ -55,6 +56,7 @@
           :key="`${idx}-${section.name}`"
           :section="section"
           :section-index="idx"
+          :contrib="routeHasContrib || sectionHasContrib(section)"
           :debug="false"
         />
       </div>
@@ -167,22 +169,28 @@ export default {
     ...mapGetters({
       rawRoot : 'getGitRawRoot',
     }),
-    iconUrl() {
+    iconUrl () {
       // console.log('-C- IndexPage > iconUrl > this.config.data :', this.config.data)
       const faviconUrl = `${this.rawRoot}${this.config.data.app_favicon}`
       // console.log('-C- IndexPage > iconUrl > faviconUrl :', faviconUrl)
       return  faviconUrl || '/favicon_multi.io'
     },
-    isHero() {
+    isHero () {
       return this.currentRoute.options && this.currentRoute.options.hero
-    }
+    },
+    routeHasContrib () {
+      return this.currentRoute.options && this.currentRoute.options.contrib
+    },
   },
   methods: {
-    getSectionName(section) {
+    getSectionName (section) {
       const sectionName = (section.options.name && section.options.name[this.locale]) || section.name
       return sectionName
     },
-    scrollTo(anchorId) {
+    sectionHasContrib (section) {
+      return section.options && section.options.contrib
+    },
+    scrollTo (anchorId) {
       // console.log('\n-C- IndexPage > scrollTo > anchorId :', anchorId)
       const element = document.querySelector(anchorId)
       // console.log('-C- IndexPage > scrollTo > element :', element)


### PR DESCRIPTION
L'option "contrib" permet d'afficher un bouton flottant sur la droite d'un élément. Ce bouton permet d'accéder directement au fichier source sur le repo.

Pour activer cette option il est nécessaire d'indiquer `contrib: true` dans les options de la route concernée ou de la section concernée.

---

## Settings

Dans le fichier de cnfig des routes, ici dans le [fichier de config des routes de la documentation Gitribute](https://github.com/multi-coop/gitribute-documentation-content/blob/main/config/routes.md?plain=1)

![Capture d’écran 2022-07-09 à 13 36 02](https://user-images.githubusercontent.com/21986727/178104157-3b889e84-c27b-4cf6-bb8f-e1f814230679.png)

---

## Résultat côté client

### Boutton au repos

<img width="822" alt="Capture d’écran 2022-07-09 à 13 37 13" src="https://user-images.githubusercontent.com/21986727/178104161-0ade4890-fcd8-4460-8950-92f418a60867.png">

### Bouton en hover

<img width="825" alt="Capture d’écran 2022-07-09 à 13 37 23" src="https://user-images.githubusercontent.com/21986727/178104163-4eb303c8-df7b-4308-8c68-f6019a803e16.png">

