### PR TITLE
same height for cards in DataGrid

### DIFF
--- a/components/contents/DataCard.vue
+++ b/components/contents/DataCard.vue
@@ -148,30 +148,6 @@
 
         </div>
 
-        <!-- button read more -->
-        <!-- <div
-          v-if="options['card-modal']"
-          class="content"
-          >
-          <b-button 
-            type="is-primary" 
-            size="is-small"
-            class="mt-3"
-            outlined
-            expanded
-            @click="showMore = !showMore; openModal()"
-            >
-            <span v-if="!showMore">
-              {{ $translate('readmore', defaultDict) }}
-              <b-icon icon="plus" size="is-small" class="pl-2"/>
-            </span>
-            <span v-if="showMore">
-              {{ $translate('readless', defaultDict) }}
-              <b-icon icon="minus" size="is-small" class="pl-2"/>
-            </span>
-          </b-button>
-        </div> -->
-
       </div>
 
 
@@ -200,6 +176,7 @@
 
 
       <!-- FOOTERS -->
+      <!-- button read more -->
       <footer
         v-if="options['card-modal']"
         class="px-3 pb-3"
@@ -227,6 +204,7 @@
         </div>
       </footer>
 
+      <!-- ext links -->
       <footer
         v-if="options && options['has-socials']"
         class="card-footer"

--- a/components/contents/DataCard.vue
+++ b/components/contents/DataCard.vue
@@ -149,7 +149,7 @@
         </div>
 
         <!-- button read more -->
-        <div
+        <!-- <div
           v-if="options['card-modal']"
           class="content"
           >
@@ -170,7 +170,7 @@
               <b-icon icon="minus" size="is-small" class="pl-2"/>
             </span>
           </b-button>
-        </div>
+        </div> -->
 
       </div>
 
@@ -199,7 +199,34 @@
       </div>
 
 
-      <!-- FOOTER -->
+      <!-- FOOTERS -->
+      <footer
+        v-if="options['card-modal']"
+        class="px-3 pb-3"
+        >
+        <div
+          class="content"
+          >
+          <b-button 
+            type="is-primary" 
+            size="is-small"
+            class="mt-3"
+            outlined
+            expanded
+            @click="showMore = !showMore; openModal()"
+            >
+            <span v-if="!showMore">
+              {{ $translate('readmore', defaultDict) }}
+              <b-icon icon="plus" size="is-small" class="pl-2"/>
+            </span>
+            <span v-if="showMore">
+              {{ $translate('readless', defaultDict) }}
+              <b-icon icon="minus" size="is-small" class="pl-2"/>
+            </span>
+          </b-button>
+        </div>
+      </footer>
+
       <footer
         v-if="options && options['has-socials']"
         class="card-footer"
@@ -498,3 +525,25 @@ export default {
 
 }
 </script>
+
+<style scoped>
+  /* .no-shadow {
+    -webkit-box-shadow: none;
+    box-shadow: none;
+  } */
+  .image-wrapper {
+    min-height: 200px;
+  }
+  .image-constrained {
+    max-height: 200px;
+    width: auto !important;
+  }
+  .card {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+  }
+  .card-content {
+    height: 100%;
+  }
+</style>

--- a/components/contents/DataCardModal.vue
+++ b/components/contents/DataCardModal.vue
@@ -425,5 +425,3 @@ export default {
   }
 }
 </script>
-
-


### PR DESCRIPTION
Spéciale dédicace @pierrecamilleri (encore une) :)

Après les options et améliorations : 

- ["dev en local" & "sommaire / plan de texte"](https://github.com/multi-coop/multi-site-app/pull/23)
- [bouton d'aide à la "contribution"](https://github.com/multi-coop/multi-site-app/commit/99c1c168dace9d56a530825d5ae708f706928c4a)
- ["couleurs custom et on n'en peut plus de ce violet moche"]( https://github.com/multi-coop/multi-site-app/commit/84914a749b365a4f1d9e2cb6031fa18319c966ad)
- et petits autres hotfixes...

...Voici un fix pour régler ce **problème de hauteurs de cartes différentes**. On est égalitaires ou pas hein ? Toutes les cartes auront maintenant la même hauteur parce que effectivement en plus ça fait plus joli !

![Capture d’écran 2022-07-14 à 13 56 03](https://user-images.githubusercontent.com/21986727/178977643-b947da1f-25d6-408f-bbd3-481b345647a2.png)

![Capture d’écran 2022-07-14 à 13 55 37](https://user-images.githubusercontent.com/21986727/178977634-a5fa0909-a891-450a-a78c-e37d860584bb.png)

