### PR TITLE
New navbar

### DIFF
--- a/components/navbar/NavbarItem.vue
+++ b/components/navbar/NavbarItem.vue
@@ -87,7 +87,8 @@
               :src="item.image"
               />
             <span
-              v-if="!item.image">
+              v-if="!item.image"
+              :class="isCurrentRoute(item) ? 'has-text-weight-bold' : ''">
               {{ $translate('label', item) }}
             </span>
           </div>

--- a/components/navbar/NavbarItem.vue
+++ b/components/navbar/NavbarItem.vue
@@ -1,0 +1,195 @@
+<template>
+  
+  <div>
+
+    <div
+      v-if="!item.disabled"> 
+
+      <!-- ITEMS - INTERNAL LINK -->
+      <b-navbar-item 
+        v-if="item.component === 'simpleLink'"
+        :to="{ path: item.link }"
+        tag="router-link"
+        class="is-size-7-touch navbar-multi"
+        >
+        <b-tooltip
+          v-if="item.icon || item.image"
+          :label="$translate('label', item)"
+          position="is-left"
+          type="is-dark">
+          <b-icon
+            v-if="item.icon && !item.image"
+            :icon="item.icon"
+            class="mr-1"
+            size="is-small"
+            />
+          <img
+            v-if="item.image"
+            class="navbar-multi-img"
+            :src="item.image"
+            />
+        </b-tooltip>
+        <span
+          v-if="!item.image"
+          :class="isCurrentRoute(item) ? 'has-text-weight-bold' : ''">
+          {{ $translate('label', item) }}
+        </span>
+      </b-navbar-item>
+
+
+      <!-- ITEMS - EXTERNAL LINK -->
+      <b-navbar-item 
+        v-if="item.component === 'extLink'"
+        :href="item.link"
+        target="_blank"
+        tag="a"
+        class="is-size-7-touch navbar-multi"
+        >
+        <b-tooltip
+          v-if="item.icon || item.image"
+          :label="$translate('label', item)"
+          position="is-left"
+          type="is-dark">
+          <b-icon
+            v-if="item.icon && !item.image"
+            :icon="item.icon"
+            />
+          <img
+            v-if="item.image"
+            class="navbar-multi-img"
+            :src="item.image"
+            />
+        </b-tooltip>
+        <span v-else>
+          {{ $translate('label', item) }}
+        </span>
+      </b-navbar-item>
+
+      <!-- DROPDOWNS -->
+      <b-navbar-dropdown 
+        v-if="item.component === 'dropdownLink'"
+        :arrowless="item.options.includes('arrowless')"
+        :hoverable="item.options.includes('hoverable')"
+        :right="isRight"
+        class="is-size-7-touch navbar-multi"
+        >
+        <template #label>
+          <div>
+            <b-icon
+              v-if="item.icon && !item.image"
+              :icon="item.icon"
+              class="mr-1"
+              size="is-small"
+              />
+            <img
+              v-if="item.image"
+              class="navbar-multi-img"
+              :src="item.image"
+              />
+            <span
+              v-if="!item.image">
+              {{ $translate('label', item) }}
+            </span>
+          </div>
+        </template>
+
+        <b-navbar-item
+          v-for="(subItem, idx) in item.submenu"
+          :key="`${idx}-${subItem.name}`"
+          :to="!subItem.separator && { path: subItem.link }"
+          :separator="subItem.separator"
+          :tag="subItem.separator ? 'hr' : 'router-link'"
+          :class="`${subItem.separator ? 'navbar-divider py-0' : 'is-size-7-touch'} ${isCurrentRoute(subItem) ? 'has-text-weight-bold' : ''}`"
+          :active="!subItem.separator && subItem.link === $route.path"
+          >
+          <span
+            v-if="!subItem.separator"
+            :class="`${ subItem.link === $route.path ? 'has-text-weight-bold' : '' }`">
+            {{ $translate('label', subItem) }}
+          </span>
+        </b-navbar-item>
+
+      </b-navbar-dropdown>
+
+
+      <!-- LOCALES -->
+      <b-navbar-dropdown 
+        v-if="item.component === 'switchLocaleDropdown'"
+        arrowless
+        hoverable
+        right
+        class="mr-4 is-size-7-touch"
+        >
+        <template #label>
+          <span class="is-uppercase">
+            {{ locale }}
+          </span>
+        </template>
+
+        <b-navbar-item 
+          v-for="loc in locales"
+          :key="loc"
+          :value="loc === locale"
+          aria-role="listitem"
+          :class="`is-size-7-touch ${loc === locale ? 'has-text-weight-bold' : ''}`"
+          @click="changeLocale(loc)"
+          >
+          {{ localesDict[loc] }}
+        </b-navbar-item>
+
+      </b-navbar-dropdown>
+
+    </div>
+
+  </div>
+
+</template>
+
+
+<script>
+import { mapState, mapActions } from 'vuex' 
+
+export default {
+  name: 'NavbarItem',
+  props: [
+    'item',
+    'isRight',
+    'isMobile'
+  ],
+  computed: {
+    ...mapState({
+      log: (state) => state.log,
+      locale: (state) => state.locale,
+      locales: (state) => state.locales,
+      localesDict: (state) => state.localesDict,
+      navbar: (state) =>  state.navbar,
+    }),
+  },
+  methods: {
+    ...mapActions({
+      updateLocale: 'updateLocale',
+    }),
+    changeLocale(loc) {
+      // console.log('\n-C- NavbarItem > changeLocale > loc :', loc)
+      // console.log('-C- NavbarItem > changeLocale > this.$route :', this.$route)
+      this.updateLocale(loc)
+    },
+    isCurrentRoute (item) {
+      const currentPath = this.$route.path
+      const isPathLink = currentPath === item.link
+      const subLinks = item.submenu && item.submenu.map(sl => sl.link)
+      const isPathSubLink = subLinks && subLinks.includes(currentPath)
+      return isPathLink || isPathSubLink
+    }
+  }
+}
+</script>
+
+<style scoped>
+
+.navbar-multi-img {
+  /* padding-top: .1em !important; */
+  max-height: 1.4em !important;
+}
+
+</style>

--- a/components/navbar/NavbarItemMobile.vue
+++ b/components/navbar/NavbarItemMobile.vue
@@ -166,7 +166,7 @@ export default {
       // console.log('-C- NavbarItemMobile > clickMenu > this.isLocaleSwitch :', this.isLocaleSwitch)
       this.$emit('updateMenu', this.itemId)
       if (item.component !== 'dropdownLink' ) {
-        this.$emit('closeMenu', this.isLocaleSwitch || !!item.submenu)
+        this.$emit('updateShowMenu', this.isLocaleSwitch || !!item.submenu)
       }
     },
     isCurrentRoute (item) {

--- a/components/navbar/NavbarItemMobile.vue
+++ b/components/navbar/NavbarItemMobile.vue
@@ -1,0 +1,191 @@
+<template>
+
+  <b-menu-item
+    v-if="!item.disabled"
+    :active="isActive"
+    class="navbar-mobile-item"
+    :tag="itemTag"
+    :to="isSimpleLink && { path: item.link, query: { locale: locale } }"
+    :href="isExtLink && item.link"
+    :target="isExtLink && '_blank'"
+    @click="clickMenu(isDropdown || isLocaleSwitch)"
+    >
+
+    <template #label>
+      <b-icon
+        v-if="item.icon && !item.image"
+        class="mr-2"
+        size="is-small"
+        :icon="item.icon"
+        />
+      <img
+        v-if="item.image"
+        class="navbar-multi-img mr-2"
+        :src="item.image"
+        />
+      <span
+        v-if="!isLocaleSwitch"
+        :class="isCurrentRoute(item) ? 'has-text-weight-bold' : ''">
+        {{ $translate('label', item) }}
+      </span>
+      <span v-else>
+        <b-icon
+          class="mr-2"
+          size="is-small"
+          icon="translate"
+          />
+        {{ localesDict[locale] }}
+      </span>
+    </template>
+
+    <!-- DROPDOWNS -->
+    <template
+      v-if="item.component === 'dropdownLink'">
+      <li
+        v-for="(sub, idx) in submenuItems"
+        :key="`sub-${idx}-${sub.name}`"
+        class="navbar-mobile-item"
+        >
+        <b-button
+          :class="`has-text-left my-0 py-0 px-1 submenu ${isCurrentRoute(sub) ? 'has-text-weight-bold' : ''}`"
+          type="is-text"
+          :tag="sub.component === 'simpleLink' ? 'router-link' : 'a'"
+          :to="sub.component === 'simpleLink' && { path: sub.link, query: { locale: locale } }"
+          :href="sub.component === 'extLink' && sub.link"
+          :target="sub.component === 'extLink' && '_blank'"
+          @click="clickMenu(false)"
+          @mouseover="hover = `sub-${idx}-${sub.name}`"
+          @mouseleave="hover = undefined"
+          >
+          {{ $translate('label', sub) }}
+        </b-button>
+      </li>
+    </template>
+
+    <!-- LOCALES -->
+    <template
+      v-if="item.component === 'switchLocaleDropdown'">
+      <li
+        v-for="loc in locales"
+        :key="loc"
+        class="navbar-mobile-item">
+        <b-button
+          :class="`has-text-left my-0 py-0 px-1 submenu ${loc === locale ? 'has-text-weight-bold' : ''}`"
+          type="is-text"
+          tag="a"
+          @click="changeLocale(loc)"
+          @mouseover="hover = loc"
+          @mouseleave="hover = undefined"
+          >
+          <span class="is-uppercase">
+            {{ loc }}
+          </span>
+          -
+          {{ localesDict[loc] }}
+        </b-button>
+      </li>
+    </template>
+
+  </b-menu-item>
+
+</template>
+
+
+<script>
+import { mapState, mapActions } from 'vuex' 
+
+export default {
+  name: 'NavbarItemMobile',
+  props: [
+    'item'
+  ],
+  data () {
+    return {
+      isActive: false,
+      hover: undefined
+    }
+  },
+  computed: {
+    ...mapState({
+      log: (state) => state.log,
+      locale: (state) => state.locale,
+      locales: (state) => state.locales,
+      localesDict: (state) => state.localesDict,
+      navbar: (state) =>  state.navbar,
+    }),
+    isSimpleLink () {
+      return this.item.component === 'simpleLink'
+    },
+    isExtLink () {
+      return this.item.component === 'extLink'
+    },
+    isDropdown () {
+      return this.item.component === 'dropdownLink'
+    },
+    isLocaleSwitch () {
+      return this.item.component === 'switchLocaleDropdown'
+    },
+    itemTag () {
+      let tag
+      switch (this.item.component) {
+        case 'simpleLink':
+          tag = 'router-link'
+          break
+        case 'extLink':
+          tag = 'a'
+          break
+        default:
+          break
+      }
+      return tag
+    },
+    submenuItems () {
+      return this.item.submenu.filter(i => !i.separator)
+    }
+  },
+  methods: {
+    ...mapActions({
+      updateLocale: 'updateLocale',
+    }),
+    changeLocale(loc) {
+      // console.log('\n-C- NavbarItemMobile > changeLocale > loc :', loc)
+      // console.log('-C- NavbarItemMobile > changeLocale > this.$route :', this.$route)
+      this.updateLocale(loc)
+    },
+    clickMenu (ignore=false) {
+      this.isActive = !this.isActive
+      if (!ignore) {
+        this.$emit('closeMenu')
+      }
+    },
+    isCurrentRoute (item) {
+      const currentPath = this.$route.path
+      const isPathLink = currentPath === item.link
+      const subLinks = item.submenu && item.submenu.map(sl => sl.link)
+      const isPathSubLink = subLinks && subLinks.includes(currentPath)
+      return isPathLink || isPathSubLink
+    }
+  }
+}
+</script>
+
+<style scoped>
+
+.navbar-multi-img {
+  max-height: 1em !important;
+}
+ul > li {
+  padding-bottom: 0;
+}
+.button.submenu {
+  height: 1.75em;
+}
+</style>
+
+<style>
+
+li.navbar-mobile-item > a {
+  text-decoration: none !important;
+} 
+
+</style>

--- a/components/navbar/NavbarItemMobile.vue
+++ b/components/navbar/NavbarItemMobile.vue
@@ -2,16 +2,21 @@
 
   <b-menu-item
     v-if="!item.disabled"
-    :active="isActive"
     class="navbar-mobile-item"
+    :active="isExpanded"
+    :expanded="isExpanded"
     :tag="itemTag"
     :to="isSimpleLink && { path: item.link, query: { locale: locale } }"
     :href="isExtLink && item.link"
     :target="isExtLink && '_blank'"
-    @click="clickMenu(isDropdown || isLocaleSwitch)"
+    @click.native="clickMenu(item)"
     >
 
     <template #label>
+      <!-- DEBUGGING -->
+      <!-- <div>
+        activeItem: <code>{{ activeItem }}</code>
+      </div> -->
       <b-icon
         v-if="item.icon && !item.image"
         class="mr-2"
@@ -53,7 +58,7 @@
           :to="sub.component === 'simpleLink' && { path: sub.link, query: { locale: locale } }"
           :href="sub.component === 'extLink' && sub.link"
           :target="sub.component === 'extLink' && '_blank'"
-          @click="clickMenu(false)"
+          @click.native="clickMenu(sub)"
           @mouseover="hover = `sub-${idx}-${sub.name}`"
           @mouseleave="hover = undefined"
           >
@@ -97,11 +102,12 @@ import { mapState, mapActions } from 'vuex'
 export default {
   name: 'NavbarItemMobile',
   props: [
-    'item'
+    'item',
+    'itemId',
+    'activeItem'
   ],
   data () {
     return {
-      isActive: false,
       hover: undefined
     }
   },
@@ -141,6 +147,9 @@ export default {
     },
     submenuItems () {
       return this.item.submenu.filter(i => !i.separator)
+    },
+    isExpanded () {
+      return this.itemId === this.activeItem
     }
   },
   methods: {
@@ -152,10 +161,12 @@ export default {
       // console.log('-C- NavbarItemMobile > changeLocale > this.$route :', this.$route)
       this.updateLocale(loc)
     },
-    clickMenu (ignore=false) {
-      this.isActive = !this.isActive
-      if (!ignore) {
-        this.$emit('closeMenu')
+    clickMenu (item) {
+      // console.log('\n-C- NavbarItemMobile > clickMenu > item :', item)
+      // console.log('-C- NavbarItemMobile > clickMenu > this.isLocaleSwitch :', this.isLocaleSwitch)
+      this.$emit('updateMenu', this.itemId)
+      if (item.component !== 'dropdownLink' ) {
+        this.$emit('closeMenu', this.isLocaleSwitch || !!item.submenu)
       }
     },
     isCurrentRoute (item) {

--- a/components/navbar/NavbarSite.vue
+++ b/components/navbar/NavbarSite.vue
@@ -70,7 +70,10 @@
                 v-for="(item, idx) in navbar.data['buttons-left']"
                 :key="`nabar-item-right-${idx}-${item.name}`"
                 :item="item"
-                @closeMenu="showMobileMenu = false"/>
+                :item-id="`${idx}-${item.name}`"
+                :active-item="activeItemMobile"
+                @updateMenu="updateMobileMenu"
+                @closeMenu="updateShowMobileMenu"/>
             </b-menu-list>
           </b-menu>
         </div>
@@ -84,7 +87,10 @@
                 v-for="(item, idx) in navbar.data['buttons-right']"
                 :key="`nabar-item-right-${idx}-${item.name}`"
                 :item="item"
-                @closeMenu="showMobileMenu = false"/>
+                :item-id="`${idx}-${item.name}`"
+                :active-item="activeItemMobile"
+                @updateMenu="updateMobileMenu"
+                @closeMenu="updateShowMobileMenu"/>
             </b-menu-list>
           </b-menu>
         </div>
@@ -106,7 +112,8 @@ export default {
   },
   data () {
     return {
-      showMobileMenu: false
+      showMobileMenu: false,
+      activeItemMobile: undefined
     }
   },
   computed: {
@@ -124,6 +131,14 @@ export default {
     getLink (link) {
       const srcLink = link && link.startsWith('./') ? `${this.rawRoot}${link}` : link
       return srcLink
+    },
+    updateMobileMenu (ev) {
+      // console.log('\n-C- NavbarSite > updateMobileMenu > ev :', ev)
+      this.activeItemMobile = ev
+    },
+    updateShowMobileMenu (ev) {
+      // console.log('\n-C- NavbarSite > updateShowMobileMenu > ev :', ev)
+      this.showMobileMenu = ev
     }
   }
 }
@@ -131,7 +146,8 @@ export default {
 
 <style scoped>
   .navbar-mobile-menu {
-    box-shadow: 0 15px 10px 2px white;
+    /* box-shadow: 0 15px 10px 2px lightgrey; */
+    box-shadow: 0 8px 16px hsla(0,0%,4%,.2);
     max-height: 75%;
     overflow: hidden;
   }
@@ -140,7 +156,7 @@ export default {
     left: 0;
     position: fixed;
     right: 0;
-    z-index: 30;
+    z-index: 90;
   }
   .navbar-mobile-menu-content {
     overflow-y: auto;

--- a/components/navbar/NavbarSite.vue
+++ b/components/navbar/NavbarSite.vue
@@ -73,7 +73,7 @@
                 :item-id="`${idx}-${item.name}`"
                 :active-item="activeItemMobile"
                 @updateMenu="updateMobileMenu"
-                @closeMenu="updateShowMobileMenu"/>
+                @updateShowMenu="updateShowMobileMenu"/>
             </b-menu-list>
           </b-menu>
         </div>
@@ -90,7 +90,7 @@
                 :item-id="`${idx}-${item.name}`"
                 :active-item="activeItemMobile"
                 @updateMenu="updateMobileMenu"
-                @closeMenu="updateShowMobileMenu"/>
+                @updateShowMenu="updateShowMobileMenu"/>
             </b-menu-list>
           </b-menu>
         </div>

--- a/components/navbar/NavbarSite.vue
+++ b/components/navbar/NavbarSite.vue
@@ -1,0 +1,148 @@
+<template>
+    
+  <nav
+    class="navbar has-navbar-centered is-fixed-top"
+    role="navigation"
+    aria-label="main navigation">
+    <!-- BRAND -->
+    <div class="navbar-brand">
+      <router-link
+        class="navbar-item"
+        :to="{ path: '/?locale=' + locale }">
+        <img
+          :src="getLink(navbar.data['logo-left'])"
+          width="auto"
+          height=".9em">
+      </router-link>
+
+      <!-- BURGER -->
+      <a
+        :class="`navbar-burger ${showMobileMenu ? 'is-active' : ''}`"
+        role="button"
+        aria-label="menu"
+        aria-expanded="false"
+        data-target="multiSiteAppNavbar"
+        @click="showMobileMenu = !showMobileMenu">
+        <span aria-hidden="true"></span>
+        <span aria-hidden="true"></span>
+        <span aria-hidden="true"></span>
+      </a>
+    </div>
+
+    <!-- MENUS -->
+    <div id="multiSiteAppNavbar" class="navbar-menu">
+      <!-- START -->
+      <div
+        v-if="navbar.data['buttons-left']"
+        class="navbar-start">
+        <!-- LOOP -->
+        <NavbarItem
+          v-for="(item, idx) in navbar.data['buttons-left']"
+          :key="`nabar-item-left-${idx}-${item.name}`"
+          :item="item"/>
+      </div>
+
+      <!-- END -->
+      <div
+        v-if="navbar.data['buttons-right']"
+        class="navbar-end">
+        <!-- LOOP -->
+        <NavbarItem
+          v-for="(item, idx) in navbar.data['buttons-right']"
+          :key="`nabar-item-right-${idx}-${item.name}`"
+          :item="item"
+          :is-right="true"/>
+      </div>
+    </div>
+
+    <!-- MOBILE MENU -->
+    <div 
+      v-show="showMobileMenu"
+      class="navbar-mobile-menu is-fixed-top is-hidden-desktop has-background-white-ter mt-0 px-6">
+      <div class="navbar-mobile-menu-content columns is-centered">
+        <!-- LEFT -->
+        <div 
+          v-if="navbar.data['buttons-left']"
+          class="column is-5">
+          <b-menu>
+            <b-menu-list>
+              <NavbarItemMobile
+                v-for="(item, idx) in navbar.data['buttons-left']"
+                :key="`nabar-item-right-${idx}-${item.name}`"
+                :item="item"
+                @closeMenu="showMobileMenu = false"/>
+            </b-menu-list>
+          </b-menu>
+        </div>
+        <!-- RIGHT -->
+        <div
+          v-if="navbar.data['buttons-right']"
+          class="column is-5">
+          <b-menu>
+            <b-menu-list>
+              <NavbarItemMobile
+                v-for="(item, idx) in navbar.data['buttons-right']"
+                :key="`nabar-item-right-${idx}-${item.name}`"
+                :item="item"
+                @closeMenu="showMobileMenu = false"/>
+            </b-menu-list>
+          </b-menu>
+        </div>
+      </div>
+    </div>
+  </nav>
+
+</template>
+
+<script>
+
+import { mapState, mapGetters } from 'vuex' 
+
+export default {
+  name: 'NavbarSite',
+  components: {
+    NavbarItem: () => import(/* webpackChunkName: "NavbarItem" */ '~/components/navbar/NavbarItem.vue'),
+    NavbarItemMobile: () => import(/* webpackChunkName: "NavbarItemMobile" */ '~/components/navbar/NavbarItemMobile.vue'),
+  },
+  data () {
+    return {
+      showMobileMenu: false
+    }
+  },
+  computed: {
+    ...mapState({
+      log: (state) => state.log,
+      locale: (state) => state.locale,
+      navbar: (state) =>  state.navbar,
+      gitInfos: (state) =>  state.gitInfos,
+    }),
+    ...mapGetters({
+      rawRoot: 'getGitRawRoot',
+    })
+  },
+  methods: {
+    getLink (link) {
+      const srcLink = link && link.startsWith('./') ? `${this.rawRoot}${link}` : link
+      return srcLink
+    }
+  }
+}
+</script>
+
+<style scoped>
+  .navbar-mobile-menu {
+    box-shadow: 0 15px 10px 2px white;
+    max-height: 75%;
+    overflow: hidden;
+  }
+  .navbar-mobile-menu.is-fixed-top {
+    top: 52px;
+    left: 0;
+    position: fixed;
+    right: 0;
+    z-index: 30;
+  }
+  .navbar-mobile-menu-content {
+    overflow-y: auto;
+  }
+</style>

--- a/components/navbar/NavbarSite.vue
+++ b/components/navbar/NavbarSite.vue
@@ -59,7 +59,7 @@
     <div 
       v-show="showMobileMenu"
       class="navbar-mobile-menu is-fixed-top is-hidden-desktop has-background-white-ter mt-0 px-6">
-      <div class="navbar-mobile-menu-content columns is-centered pb-4">
+      <div class="navbar-mobile-menu-content columns is-centered py-4">
         <!-- LEFT -->
         <div 
           v-if="navbar.data['buttons-left']"

--- a/components/navbar/NavbarSite.vue
+++ b/components/navbar/NavbarSite.vue
@@ -59,7 +59,7 @@
     <div 
       v-show="showMobileMenu"
       class="navbar-mobile-menu is-fixed-top is-hidden-desktop has-background-white-ter mt-0 px-6">
-      <div class="navbar-mobile-menu-content columns is-centered">
+      <div class="navbar-mobile-menu-content columns is-centered pb-4">
         <!-- LEFT -->
         <div 
           v-if="navbar.data['buttons-left']"

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -3,8 +3,9 @@
     class=""
     >
 
-    <!-- navbar -->
-    <NavbarComponent/>
+    <!-- NAVBAR -->
+    <!-- <NavbarComponent/> -->
+    <NavbarSite/>
 
     <!-- menu left -->
     <section class="main-content columns">
@@ -27,7 +28,7 @@
 
     </section>
 
-    <!-- footers -->
+    <!-- FOOTERS -->
     <FooterComponent/>
     <CreditsFooter/>
 
@@ -40,7 +41,8 @@ import { mapState } from 'vuex'
 export default {
   name: 'DefaultLayout',
   components: {
-    NavbarComponent: () => import(/* webpackChunkName: "NavbarComponent" */ '~/components/navbar/NavbarComponent.vue'),
+    // NavbarComponent: () => import(/* webpackChunkName: "NavbarComponent" */ '~/components/navbar/NavbarComponent.vue'),
+    NavbarSite: () => import(/* webpackChunkName: "NavbarComponent" */ '~/components/navbar/NavbarSite.vue'),
     FooterComponent: () => import(/* webpackChunkName: "FooterComponent" */ '~/components/footer/FooterComponent.vue'),
     CreditsFooter: () => import(/* webpackChunkName: "CreditsFooter" */ '~/components/footer/CreditsFooter.vue')
   },

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -371,7 +371,7 @@ export default {
       const box = this.getElementBoundingBox(anchorId)
       if (box.isActive) {
         this.activeSection = anchorId
-        this.updateUrl(anchorId, this.isAutoScrolling)
+        // this.updateUrl(anchorId, this.isAutoScrolling)
       }
       return box.isActive
     }

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -156,7 +156,7 @@
         a:not(.navbar-link, .navbar-item, .credit-text), .navbar-link:hover, .navbar-item:hover, a.navbar-item.is-active {
           color: {{ configPrimaryColor }} !important;
         }
-        a:not(.navbar-link, .navbar-item, .button) {
+        a:not(.navbar-link, .navbar-item, .button, .navbar-mobile-item) {
           text-decoration: underline;
         }
         .floating-menu-item > a, nav.tabs  > ul > li > a {


### PR DESCRIPTION
@pierrecamilleri 

Les menus de la navbar commençaient moi aussi à m’ennuyer sur mobile, notamment pour la doc de gitribute qui a beaucoup de sous parties.

J’ai donc bidouillé un peu tout ça pour inclure des menus déroulants, du responsive plus propre, et quelques détails d'UX (genre mettre en gras le texte du bouton de dropdown si on se trouve sur une url d'un de ses "sous-liens").  

---

### AVANT

---

<img width="617" alt="Capture d’écran 2022-07-18 à 19 16 24" src="https://user-images.githubusercontent.com/21986727/179566738-724fbdb1-d96e-4f5c-9afe-8b8584cf350b.png">

---

### APRES 

---

<img width="606" alt="Capture d’écran 2022-07-18 à 19 15 07" src="https://user-images.githubusercontent.com/21986727/179566766-00f35823-3d49-4a6b-8867-bb772046df90.png">

