### PR TITLE
add navbar tag option before links and buttons

### DIFF
--- a/components/navbar/NavbarItem.vue
+++ b/components/navbar/NavbarItem.vue
@@ -11,8 +11,7 @@
         :to="buildTo(item)"
         tag="router-link"
         class="is-size-7-touch navbar-multi"
-        @click.native="trackEvent(item.link, 'GoToPage', 'Navbar')"
-        >
+        @click.native="trackEvent(item.link, 'GoToPage', 'Navbar')">
         <b-tooltip
           v-if="item.icon || item.image"
           :label="$translate('label', item)"
@@ -38,6 +37,7 @@
         <span
           v-if="!item.image"
           :class="isCurrentRoute(item) ? 'has-text-weight-bold' : ''">
+          <NavbarItemTag :item="item"/>
           {{ $translate('label', item) }}
         </span>
       </b-navbar-item>
@@ -74,6 +74,7 @@
           </span>
         </b-tooltip>
         <span v-else>
+          <NavbarItemTag :item="item"/>
           {{ $translate('label', item) }}
         </span>
       </b-navbar-item>
@@ -102,6 +103,7 @@
             <span
               v-if="!item.image"
               :class="isCurrentRoute(item) ? 'has-text-weight-bold' : ''">
+              <NavbarItemTag :item="item"/>
               {{ $translate('label', item) }}
             </span>
           </div>
@@ -124,6 +126,7 @@
             <span
               v-if="!subItem.separator"
               :class="`${ subItem.link === $route.path ? 'has-text-weight-bold' : '' }`">
+              <NavbarItemTag :item="subItem"/>
               {{ $translate('label', subItem) }}
             </span>
           </b-navbar-item>
@@ -137,6 +140,7 @@
             @click.native="trackLink(subItem.link)"
             >
             <span>
+              <NavbarItemTag :item="subItem"/>
               {{ $translate('label', subItem) }}
             </span>
           </b-navbar-item>
@@ -187,6 +191,9 @@ import navbar from '~/mixins/navbar'
 
 export default {
   name: 'NavbarItem',
+  components: {
+    NavbarItemTag: () => import(/* webpackChunkName: "NavbarItemTag" */ '~/components/navbar/NavbarItemTag.vue')
+  },
   mixins: [matomo, navbar],
   props: {
     item: {

--- a/components/navbar/NavbarItemMobile.vue
+++ b/components/navbar/NavbarItemMobile.vue
@@ -31,6 +31,7 @@
       <span
         v-if="!isLocaleSwitch"
         :class="isCurrentRoute(item) ? 'has-text-weight-bold' : ''">
+        <NavbarItemTag :item="item"/>
         {{ $translate('label', item) }}
       </span>
       <span v-else>
@@ -62,6 +63,7 @@
           @mouseover="hover = `sub-${idx}-${sub.name}`"
           @mouseleave="hover = undefined"
           >
+          <NavbarItemTag :item="sub"/>
           {{ $translate('label', sub) }}
         </b-button>
       </li>
@@ -104,6 +106,9 @@ import navbar from '~/mixins/navbar'
 
 export default {
   name: 'NavbarItemMobile',
+  components: {
+    NavbarItemTag: () => import(/* webpackChunkName: "NavbarItemTag" */ '~/components/navbar/NavbarItemTag.vue')
+  },
   mixins: [matomo, navbar],
   props: {
     item: {

--- a/components/navbar/NavbarItemTag.vue
+++ b/components/navbar/NavbarItemTag.vue
@@ -1,0 +1,28 @@
+<template>
+  <b-tag
+    v-if="item.tag"
+    class="mr-1"
+    :type="`is-${item.tag.type}`"
+    size="is-small"
+    :rounded="item.tag.rounded"
+    :icon="item.tag.icon">
+    <span
+      v-if="item.tag.label"
+      class="has-text-weight-bold">
+      {{ $translate('label', item.tag) }}
+    </span>
+  </b-tag>
+</template>
+
+<script>
+
+export default {
+  name: 'NavbarItemTag',
+  props: {
+    item: {
+      default: undefined,
+      type: Object
+    }
+  }
+}
+</script>


### PR DESCRIPTION
This PR allows to set a tag before a navbar link, if activated and set in the navbar config

This feature could be usefull in case we have a new page or a new link we’d like users to focus directly on (some new blog post, a new section, etc…)

Result should look like that => 

---

![Capture d’écran 2022-09-15 à 20 23 09](https://user-images.githubusercontent.com/21986727/190481068-0b1956d0-08ae-482a-91d7-99d40132a300.png)
