### PR TITLE
if statement for left-side icons on ButtonComponent

### DIFF
--- a/components/buttons/ButtonsComponent.vue
+++ b/components/buttons/ButtonsComponent.vue
@@ -61,6 +61,7 @@
             @click="trackEvent(btn.link, 'BtnToExtPage', 'Content'); trackLink(btn.link)"
             >
             <b-icon
+              v-if="btn['icon-left']"
               :icon="btn['icon-left']"
               size="is-small"
               class="mr-2"


### PR DESCRIPTION
This PR aims to fix #35 

---

before fix =>

<img width="364" alt="Capture d’écran 2022-09-19 à 12 44 48" src="https://user-images.githubusercontent.com/21986727/191001364-418aa389-a192-4155-987b-ed9eb2a925ab.png">

---

after fix =>

<img width="375" alt="Capture d’écran 2022-09-19 à 12 46 42" src="https://user-images.githubusercontent.com/21986727/191001374-3bc4ab3f-0cc8-4b30-ab80-09985609713c.png">
