### PR TITLE
Fix dupes in browser history

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -458,7 +458,7 @@ export default {
     //     2000
     //   )
     // }
-    this.updateUrl(undefined, false, true)
+    // this.updateUrl(undefined, false, true)
   },
   destroyed () {
     window.removeEventListener('scroll', this.handleScroll)


### PR DESCRIPTION
Browsing on the https://www.multi.coop website seems to duplicate every page in browser history. This breaks the intuitive nature of the browser's back button, where users have to press multiple times to go back one page.

For example, loading the website and clicking once on the "Notre offre de service" button creates the following history:
![oneclic](https://user-images.githubusercontent.com/7023229/229352704-85a979d3-4f67-4c4d-ba8b-81a81ae51351.png)

Looking at the network queries, it looks like remote markdown content is also requested twice on page load.
![oneclic](https://user-images.githubusercontent.com/7023229/229352864-bc7ddaa3-22bc-49ca-86f1-f56313403439.png)

**This PR fixes the duplicates in history** by removing an obsolete (?) `updateUrl` call when mouting.

I'm not too familiar with the tech stack, but it looks like the site behaves the same without this line.

However, this PR doesn't fix the multiple calls to remote markdown content. So this might be a band-aid on a deeper issue ?